### PR TITLE
Keep AliasVar when used only in RETURNs.

### DIFF
--- a/cypher2sql/src/test/java/org/cytosm/cypher2sql/lowering/UnwrapAliasVarTests.java
+++ b/cypher2sql/src/test/java/org/cytosm/cypher2sql/lowering/UnwrapAliasVarTests.java
@@ -1,0 +1,18 @@
+package org.cytosm.cypher2sql.lowering;
+
+import org.cytosm.cypher2sql.PassAvailables;
+import org.cytosm.cypher2sql.lowering.sqltree.ScopeSelect;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ */
+public class UnwrapAliasVarTests extends BaseLDBCTests {
+
+    @Test
+    public void testAliasVarIsKeptOnReturn() throws Exception {
+        String cypher = "MATCH (a:Person) RETURN a.firstName AS a";
+        ScopeSelect tree = PassAvailables.cypher2sqlOnExpandedPaths(getGTopInterface(), cypher);
+        Assert.assertEquals(1, tree.ret.exportedItems.size());
+    }
+}


### PR DESCRIPTION
There is still some work to do with `AliasVar`s. I originally thought we could remove them entirely but after starting the work on the `COUNT` function, I realized that this would not be possible and the code around `AliasVar` was becoming incredibly complex. Pull request #3 made all the `Var` classes isolated from the expression tree and introduced the `RenderingContext`.

Note that there is still works to be done on the `RenderingContext` with `AliasVar`s.