### PR TITLE
changed from synonyms to types on gtop specification

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -131,26 +131,26 @@ Let's go for an example of the Abstraction Level gTop. The bipartite property-gr
 {
 "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "attributes" : [ "id", "title", "released", "tagline" ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "attributes" : [ "id", "name", "born" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "directed" ],
+      "types" : [ "directed" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "acted_in" ],
+      "types" : [ "acted_in" ],
       "attributes" : [ "role" ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "produced" ],
+      "types" : [ "produced" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
@@ -160,7 +160,7 @@ Let's go for an example of the Abstraction Level gTop. The bipartite property-gr
 }
 ```
 
-There are two nodes types - called movie and person. The <strong>synonyms</strong> attribute labels a given node type - and the same type can have multiple labels, hence the origin of the attribute name "synonyms".
+There are two nodes types - called movie and person. The <strong>types</strong> attribute labels a given node type - and the same type can have multiple labels, hence the origin of the attribute name "types".
 The attributes of a node type are also listed. On the Abstraction layer, it is not important to define how an attribute is implemented (e.g. if it is an Integer, Text, etc).
 On the edge side, one can see that "acted_in" is a directed edge, with one attribute called "role". It also connects Person nodes towards Movie nodes.
 
@@ -181,7 +181,7 @@ The property-graph,serialized in the <strong>abstraction layer</strong> above, a
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "tableName" : "movie",
       "id" : [ {
         "columnName" : "id",
@@ -207,7 +207,7 @@ The property-graph,serialized in the <strong>abstraction layer</strong> above, a
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "tableName" : "person",
       "id" : [ {
         "columnName" : "id",
@@ -230,7 +230,7 @@ The property-graph,serialized in the <strong>abstraction layer</strong> above, a
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -244,7 +244,7 @@ The property-graph,serialized in the <strong>abstraction layer</strong> above, a
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -262,7 +262,7 @@ The property-graph,serialized in the <strong>abstraction layer</strong> above, a
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -285,7 +285,7 @@ The mapping of every node is done in the "Implementation Node" attribute. For a 
 
 ```json
 {
-         "synonyms" : [ "person" ],
+         "types" : [ "person" ],
          "tableName" : "person",
          "id" : [ {
            "columnName" : "id",
@@ -309,7 +309,7 @@ The mapping of every node is done in the "Implementation Node" attribute. For a 
  }
 ```
        
-ImplementationNode JSON attribute defines how to extract nodes of synonym "Person" from a RDBMS. There may be many sources of nodes of type "Person" in the system. The GQL (OpenCypher) to SQL compiler should take care of retrieving all the nodes from the relational system.
+ImplementationNode JSON attribute defines how to extract nodes of type "Person" from a RDBMS. There may be many sources of nodes of type "Person" in the system. The GQL (OpenCypher) to SQL compiler should take care of retrieving all the nodes from the relational system.
 
 In this example, nodes of type "person" are stored in the table called "person". Cytosm assumes that every node may have an id. In this scenario, there is an id of type "INTEGER", from the table column called "id". In some special cases, UIDs may come from multiple columns, this is solved by the "concatenationPosition" that concatenates multiple columns together in order to generate an ID. Other operations to generate UIDs may be added in the future.
 
@@ -320,7 +320,7 @@ On the edge implementation side, there's the following example:
 
 ```json
 {
-         "synonyms" : [ "acted_in" ],
+         "types" : [ "acted_in" ],
          "paths" : [ {
            "traversalHops" : [ {
              "sourceTableName" : "person",

--- a/common/docs/movies.gtop
+++ b/common/docs/movies.gtop
@@ -2,26 +2,26 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "attributes" : [ "id", "title", "released", "tagline" ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "attributes" : [ "id", "name", "born" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "attributes" : [ "role" ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
@@ -33,7 +33,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "tableName" : "movie",
       "id" : [ {
         "columnName" : "id",
@@ -59,7 +59,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "tableName" : "person",
       "id" : [ {
         "columnName" : "id",
@@ -82,7 +82,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -96,7 +96,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -114,7 +114,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",

--- a/common/resources/gTopSchema.json
+++ b/common/resources/gTopSchema.json
@@ -55,7 +55,7 @@
 							}
 						}
 					},
-					"synonyms": {
+					"types": {
 						"type": "array",
 						"items": {
 							"type": "string"
@@ -118,7 +118,7 @@
 							}
 						}
 					},
-					"synonyms": {
+					"types": {
 						"type": "array",
 						"items": {
 							"type": "string"

--- a/common/src/main/java/org/cytosm/common/gtop/GTopInterface.java
+++ b/common/src/main/java/org/cytosm/common/gtop/GTopInterface.java
@@ -74,53 +74,53 @@ interface GTopInterface {
     void setImplementationEdges(final List<ImplementationEdge> edges);
 
     /***
-     * @return a deduplicated edge synonyms list.
+     * @return a deduplicated edge types list.
      */
     @JsonIgnore
-    List<String> getAllEdgeSynonyms();
+    List<String> getAllEdgeTypes();
 
     /***
-     * @return a deduplicated edge synonyms list.
+     * @return a deduplicated edge types list.
      */
     @JsonIgnore
-    List<String> getAllNodeSynonyms();
+    List<String> getAllNodeTypes();
 
     /***
-     * Finds the Abstraction Edges for a given synonym.
+     * Finds the Abstraction Edges for a given types.
      *
-     * @param synonym
+     * @param types
      * @return
      */
     @JsonIgnore
-    List<AbstractionEdge> getAbstractionEdgesBySynonym(final String synonym);
+    List<AbstractionEdge> getAbstractionEdgesByTypes(final String types);
 
 
     /**
-     * Finds an abstract node by synonyms.
+     * Finds an abstract node by types.
      *
-     * @param synonym
+     * @param types
      * @return
      */
     @JsonIgnore
-    List<AbstractionNode> getAbstractionNodesBySynonym(final String synonym);
+    List<AbstractionNode> getAbstractionNodesByTypes(final String types);
 
     /**
-     * Finds an Implementation nodes by synonym.
+     * Finds an Implementation nodes by type.
      *
-     * @param synonym
+     * @param type
      * @return
      */
     @JsonIgnore
-    List<ImplementationNode> getImplementationNodesBySynonym(final String synonym);
+    List<ImplementationNode> getImplementationNodesByType(final String type);
 
     /***
-     * Finds an Implementation edges by synonym.
+     * Finds an Implementation edges by type.
      *
-     * @param synonym
+     * @param type
      * @return
      */
     @JsonIgnore
-    List<ImplementationEdge> getImplementationEdgeBySynonym(final String synonym);
+    List<ImplementationEdge> getImplementationEdgeByType(final String type);
 
     /***
      * Return the implementations for a given node. The node can be represented in several tables.
@@ -167,7 +167,7 @@ interface GTopInterface {
      * @return list of Abstraction Edges
      */
     @JsonIgnore
-    List<AbstractionEdge> getAllAbstractEdgesForNodeSynonms(final List<String> synonms);
+    List<AbstractionEdge> getAllAbstractEdgesForNodeTypes(final List<String> types);
 
     /**
      * Get the edges that connect nodeA to nodeB and are directed.
@@ -193,7 +193,7 @@ interface GTopInterface {
      * Return destination node types for a given edge.
      *
      * @param edge edge to lookup
-     * @return list node synonyms that this edge directs to
+     * @return list node types that this edge directs to
      */
     @JsonIgnore
     List<AbstractionNode> getDestinationNodesForEdge(final AbstractionEdge analyzedEdge);
@@ -202,7 +202,7 @@ interface GTopInterface {
      * Return all node types associated with a given edge.
      *
      * @param edge edge to lookup
-     * @return List of nodes synonyms associated with this edge
+     * @return List of nodes types associated with this edge
      */
     @JsonIgnore
     List<AbstractionNode> getNodesForEdge(final AbstractionEdge edge);

--- a/common/src/main/java/org/cytosm/common/gtop/GTopInterfaceImpl.java
+++ b/common/src/main/java/org/cytosm/common/gtop/GTopInterfaceImpl.java
@@ -90,78 +90,78 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
     // Interface-friendly methods
 
     /***
-     * @return a deduplicated edges synonyms list.
+     * @return a deduplicated edges types list.
      */
     @Override
     @JsonIgnore
-    public List<String> getAllEdgeSynonyms() {
-        final List<String> withDuplucationsAllEdgeSynonyms = new ArrayList<>();
+    public List<String> getAllEdgeTypes() {
+        final List<String> withDuplicationsAllEdgeTypes = new ArrayList<>();
 
         gtop.getAbstractionLevel().getAbstractionEdges()
-                .forEach(edge -> withDuplucationsAllEdgeSynonyms.addAll(edge.getSynonyms()));
+                .forEach(edge -> withDuplicationsAllEdgeTypes.addAll(edge.getTypes()));
 
         // de-duplicate:
-        List<String> allEdgesSynonyms =
-                withDuplucationsAllEdgeSynonyms.stream().distinct().collect(Collectors.toList());
+        List<String> allEdgesTypes =
+                withDuplicationsAllEdgeTypes.stream().distinct().collect(Collectors.toList());
 
-        return allEdgesSynonyms;
+        return allEdgesTypes;
     }
 
     /***
-     * @return a deduplicated nodes synonyms list.
+     * @return a deduplicated nodes types list.
      */
     @Override
     @JsonIgnore
-    public List<String> getAllNodeSynonyms() {
-        final List<String> withDuplucationsAllNodeSynonyms = new ArrayList<>();
+    public List<String> getAllNodeTypes() {
+        final List<String> withDuplucationsAllNodeTypes = new ArrayList<>();
 
         gtop.getAbstractionLevel().getAbstractionNodes()
-                .forEach(node -> withDuplucationsAllNodeSynonyms.addAll(node.getSynonyms()));
+                .forEach(node -> withDuplucationsAllNodeTypes.addAll(node.getTypes()));
 
         // de-duplicate:
-        List<String> allNodesSynonyms =
-                withDuplucationsAllNodeSynonyms.stream().distinct().collect(Collectors.toList());
+        List<String> allNodesTypes =
+                withDuplucationsAllNodeTypes.stream().distinct().collect(Collectors.toList());
 
-        return allNodesSynonyms;
+        return allNodesTypes;
     }
 
     /***
-     * Finds an Abstraction Edge by synonym.
+     * Finds an Abstraction Edge by type.
      *
-     * @param synonym
+     * @param types
      * @return
      */
     @Override
     @JsonIgnore
-    public List<AbstractionEdge> getAbstractionEdgesBySynonym(final String synonym) {
+    public List<AbstractionEdge> getAbstractionEdgesByTypes(final String types) {
 
         List<AbstractionEdge> edgeList = new ArrayList<>();
-        String synonymLower = synonym.toLowerCase();
+        String typeLower = types.toLowerCase();
 
         edgeList = gtop
-                .getAbstractionLevel().getAbstractionEdges().stream().filter(edge -> edge.getSynonyms().stream()
-                        .map(String::toLowerCase).collect(Collectors.toList()).contains(synonymLower))
+                .getAbstractionLevel().getAbstractionEdges().stream().filter(edge -> edge.getTypes().stream()
+                        .map(String::toLowerCase).collect(Collectors.toList()).contains(typeLower))
                 .collect(Collectors.toList());
 
         return edgeList;
     }
 
     /**
-     * Finds an abstract node by synonyms.
+     * Finds an abstract node by types.
      *
-     * @param synonym
+     * @param types
      * @return
      */
     @Override
     @JsonIgnore
-    public List<AbstractionNode> getAbstractionNodesBySynonym(final String synonym) {
+    public List<AbstractionNode> getAbstractionNodesByTypes(final String types) {
 
         List<AbstractionNode> nodeList = new ArrayList<>();
-        String synonymLower = synonym.toLowerCase();
+        String typeLower = types.toLowerCase();
 
         nodeList = gtop
-                .getAbstractionLevel().getAbstractionNodes().stream().filter(node -> node.getSynonyms().stream()
-                        .map(String::toLowerCase).collect(Collectors.toList()).contains(synonymLower))
+                .getAbstractionLevel().getAbstractionNodes().stream().filter(node -> node.getTypes().stream()
+                        .map(String::toLowerCase).collect(Collectors.toList()).contains(typeLower))
                 .collect(Collectors.toList());
 
         return nodeList;
@@ -178,9 +178,9 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
     public List<AbstractionNode> findNodeAbstractions(final ImplementationNode node) {
         List<AbstractionNode> abstractions = new ArrayList<>();
 
-        // if the abstraction matches any of the implementation level synonyms, append to list.
+        // if the abstraction matches any of the implementation level types, append to list.
         abstractions = gtop.getAbstractionLevel().getAbstractionNodes().stream()
-                .filter(filteredNode -> !Collections.disjoint(filteredNode.getSynonyms(), node.getSynonyms()))
+                .filter(filteredNode -> !Collections.disjoint(filteredNode.getTypes(), node.getTypes()))
                 .collect(Collectors.toList());
 
 
@@ -215,21 +215,21 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
     /**
      * Get the edges that start or end with node.
      *
-     * @param synonms synonyms that are going used in the search
+     * @param types types that are going used in the search
      * @return list of Abstraction Edges
      */
     @Override
     @JsonIgnore
-    public List<AbstractionEdge> getAllAbstractEdgesForNodeSynonms(final List<String> synonms) {
+    public List<AbstractionEdge> getAllAbstractEdgesForNodeTypes(final List<String> types) {
 
         List<AbstractionEdge> edgeList = new ArrayList<>();
 
-        if (synonms != null && !synonms.isEmpty()) {
+        if (types != null && !types.isEmpty()) {
             for (AbstractionEdge edge : gtop.getAbstractionLevel().getAbstractionEdges()) {
                 if (edge.getSourceType().stream()
-                        .anyMatch(type -> synonms.contains(type.toLowerCase()) || type.toCharArray().equals("all"))
+                        .anyMatch(type -> types.contains(type.toLowerCase()) || type.toCharArray().equals("all"))
                         || edge.getDestinationType().stream().anyMatch(
-                                type -> synonms.contains(type.toLowerCase()) || type.toCharArray().equals("all"))) {
+                                type -> types.contains(type.toLowerCase()) || type.toCharArray().equals("all"))) {
                     edgeList.add(edge);
                 }
             }
@@ -255,10 +255,10 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
         if (sourceNode != null && destinationNode != null) {
             for (AbstractionEdge edge : gtop.getAbstractionLevel().getAbstractionEdges()) {
                 if (edge.getSourceType().stream()
-                        .anyMatch(type -> sourceNode.getSynonyms().contains(type.toLowerCase())
+                        .anyMatch(type -> sourceNode.getTypes().contains(type.toLowerCase())
                                 || type.toCharArray().equals("all"))
                         && edge.getDestinationType().stream()
-                                .anyMatch(type -> destinationNode.getSynonyms().contains(type.toLowerCase())
+                                .anyMatch(type -> destinationNode.getTypes().contains(type.toLowerCase())
                                         || type.toCharArray().equals("all"))) {
                     edgeList.add(edge);
                 }
@@ -289,7 +289,7 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
                     duplicatedEdgeNodes.addAll(this.getAbstractionNodes());
                 } else {
                     edge.getSourceType().stream()
-                            .forEach(synonym -> duplicatedEdgeNodes.addAll(this.getAbstractionNodesBySynonym(synonym)));
+                            .forEach(type -> duplicatedEdgeNodes.addAll(this.getAbstractionNodesByTypes(type)));
                 }
             }
         }
@@ -304,7 +304,7 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
      * Return destination node types for a given edge.
      *
      * @param analyzedEdge edge to lookup
-     * @return list node synonyms that this edge directs to
+     * @return list node types that this edge directs to
      */
     @Override
     @JsonIgnore
@@ -320,7 +320,7 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
                     duplicatedEdgeNodes.addAll(this.getAbstractionNodes());
                 } else {
                     edge.getDestinationType().stream()
-                            .forEach(synonym -> duplicatedEdgeNodes.addAll(this.getAbstractionNodesBySynonym(synonym)));
+                            .forEach(type -> duplicatedEdgeNodes.addAll(this.getAbstractionNodesByTypes(type)));
                 }
             }
         }
@@ -335,7 +335,7 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
      * Return all node types associated with a given edge.
      *
      * @param edge edge to lookup
-     * @return List of nodes synonyms associated with this edge
+     * @return List of nodes types associated with this edge
      */
     @Override
     @JsonIgnore
@@ -380,24 +380,24 @@ public abstract class GTopInterfaceImpl implements GTopInterface {
     public abstract void setImplementationEdges(final List<ImplementationEdge> edges);
 
     /***
-     * Finds an Implementation edge by synonym or table name reference.
+     * Finds an Implementation edge by type or table name reference.
      *
-     * @param synonym
+     * @param type
      * @return
      */
     @Override
     @JsonIgnore
-    public abstract List<ImplementationNode> getImplementationNodesBySynonym(final String synonym);
+    public abstract List<ImplementationNode> getImplementationNodesByType(final String type);
 
     /***
-     * Finds an Implementation edge by synonym or table name reference.
+     * Finds an Implementation edge by type or table name reference.
      *
-     * @param synonym
+     * @param type
      * @return
      */
     @Override
     @JsonIgnore
-    public abstract List<ImplementationEdge> getImplementationEdgeBySynonym(final String name);
+    public abstract List<ImplementationEdge> getImplementationEdgeByType(final String type);
 
     /***
      * Return the implementations for a given node. The node can be represented in several tables.

--- a/common/src/main/java/org/cytosm/common/gtop/RelationalGTopInterface.java
+++ b/common/src/main/java/org/cytosm/common/gtop/RelationalGTopInterface.java
@@ -132,43 +132,43 @@ public class RelationalGTopInterface extends GTopInterfaceImpl {
     }
 
     /***
-     * Finds an Implementation Node by synonym.
+     * Finds an Implementation Node by type.
      *
-     * @param synonym
+     * @param type
      * @return
      */
     @Override
     @JsonIgnore
-    public List<ImplementationNode> getImplementationNodesBySynonym(final String synonym) {
+    public List<ImplementationNode> getImplementationNodesByType(final String type) {
         List<ImplementationNode> foundNodes = new ArrayList<>();
-        if (synonym == null) {
+        if (type == null) {
             return foundNodes;
         }
         foundNodes = gtop
-                .getImplementationLevel().getImplementationNodes().stream().filter(node -> node.getSynonyms().stream()
-                        .map(String::toLowerCase).collect(Collectors.toList()).contains(synonym.toLowerCase()))
+                .getImplementationLevel().getImplementationNodes().stream().filter(node -> node.getTypes().stream()
+                        .map(String::toLowerCase).collect(Collectors.toList()).contains(type.toLowerCase()))
                 .collect(Collectors.toList());
 
         return foundNodes;
     }
 
     /***
-     * Finds an Implementation edge by synonym.
+     * Finds an Implementation edge by type.
      *
-     * @param synonym
+     * @param type
      * @return
      */
     @Override
     @JsonIgnore
-    public List<ImplementationEdge> getImplementationEdgeBySynonym(final String synonym) {
+    public List<ImplementationEdge> getImplementationEdgeByType(final String type) {
         List<ImplementationEdge> foundEdge = new ArrayList<>();
-        if (synonym == null) {
+        if (type == null) {
             return foundEdge;
         }
 
         foundEdge = gtop
-                .getImplementationLevel().getImplementationEdges().stream().filter(edge -> edge.getSynonyms().stream()
-                        .map(String::toLowerCase).collect(Collectors.toList()).contains(synonym.toLowerCase()))
+                .getImplementationLevel().getImplementationEdges().stream().filter(edge -> edge.getTypes().stream()
+                        .map(String::toLowerCase).collect(Collectors.toList()).contains(type.toLowerCase()))
                 .collect(Collectors.toList());
 
         return foundEdge;
@@ -185,9 +185,9 @@ public class RelationalGTopInterface extends GTopInterfaceImpl {
     public List<ImplementationNode> findNodeImplementations(final AbstractionNode node) {
         List<ImplementationNode> implementation = new ArrayList<>();
 
-        // if the implementation matches any of the abstraction level synonyms, append to list.
+        // if the implementation matches any of the abstraction level types, append to list.
         implementation = gtop.getImplementationLevel().getImplementationNodes().stream()
-                .filter(filteredNode -> !Collections.disjoint(filteredNode.getSynonyms(), node.getSynonyms()))
+                .filter(filteredNode -> !Collections.disjoint(filteredNode.getTypes(), node.getTypes()))
                 .collect(Collectors.toList());
 
         return implementation;
@@ -207,7 +207,7 @@ public class RelationalGTopInterface extends GTopInterfaceImpl {
         ImplementationEdge implementation = null;
 
         for (ImplementationEdge analyzedEdge : gtop.getImplementationLevel().getImplementationEdges()) {
-            if (!Collections.disjoint(edge.getSynonyms(), analyzedEdge.getSynonyms())) {
+            if (!Collections.disjoint(edge.getTypes(), analyzedEdge.getTypes())) {
                 implementation = analyzedEdge;
                 break;
             }
@@ -236,7 +236,7 @@ public class RelationalGTopInterface extends GTopInterfaceImpl {
     public AbstractionNode createAbstractionNodeFromImplementation(final ImplementationNode node) {
         List<String> attributsList = node.getAttributes().stream().map(attribute -> attribute.getAbstractionLevelName())
                 .collect(Collectors.toList());
-        return new AbstractionNode(node.getSynonyms(), attributsList);
+        return new AbstractionNode(node.getTypes(), attributsList);
     }
 
     @Override
@@ -250,7 +250,7 @@ public class RelationalGTopInterface extends GTopInterfaceImpl {
         // Removes duplicates
         List<String> filteredAttributes = attributesList.stream().distinct().collect(Collectors.toList());
 
-        return new AbstractionEdge(edge.getSynonyms(), filteredAttributes, new ArrayList<String>(),
+        return new AbstractionEdge(edge.getTypes(), filteredAttributes, new ArrayList<String>(),
                 new ArrayList<String>(), false);
     }
 }

--- a/common/src/main/java/org/cytosm/common/gtop/abstraction/AbstractionEdge.java
+++ b/common/src/main/java/org/cytosm/common/gtop/abstraction/AbstractionEdge.java
@@ -12,13 +12,13 @@ import java.util.List;
 public class AbstractionEdge extends AbstractionGraphComponent {
 
     /***
-     * Types of source nodes that can have this edge. It can be a list of node synonyms or the
+     * Types of source nodes that can have this edge. It can be a list of node types or the
      * classifier ALL.
      */
     protected List<String> sourceType = new ArrayList<>();
 
     /***
-     * Types of destination nodes that can have this edge. It can be a list of node synonyms or the
+     * Types of destination nodes that can have this edge. It can be a list of node types or the
      * classifier ALL.
      */
     protected List<String> destinationType = new ArrayList<>();
@@ -36,15 +36,15 @@ public class AbstractionEdge extends AbstractionGraphComponent {
     /***
      * Default constructor.
      *
-     * @param synonyms synonyms for that edge
+     * @param types types for that edge
      * @param attributes attributes of that edge.
      * @param sourceType source type of the edge
      * @param destinationType destionation type of the edge
      * @param directed is the edge directed?
      */
-    public AbstractionEdge(final List<String> synonyms, final List<String> attributes, final List<String> sourceType,
+    public AbstractionEdge(final List<String> types, final List<String> attributes, final List<String> sourceType,
             final List<String> destinationType, final boolean directed) {
-        this.synonyms = synonyms;
+        this.types = types;
         this.attributes = attributes;
         this.sourceType = sourceType;
         this.destinationType = destinationType;
@@ -97,12 +97,12 @@ public class AbstractionEdge extends AbstractionGraphComponent {
     @SuppressWarnings("checkstyle:magicnumber")
     public int hashCode() {
         // In order to produce the same hash code.
-        Collections.sort(synonyms);
+        Collections.sort(types);
         Collections.sort(attributes);
         Collections.sort(sourceType);
         Collections.sort(destinationType);
 
-        int result = synonyms != null ? synonyms.hashCode() : 0;
+        int result = types != null ? types.hashCode() : 0;
         result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
         result = 31 * result + (sourceType != null ? sourceType.hashCode() : 0);
         result = 31 * result + (destinationType != null ? destinationType.hashCode() : 0);

--- a/common/src/main/java/org/cytosm/common/gtop/abstraction/AbstractionGraphComponent.java
+++ b/common/src/main/java/org/cytosm/common/gtop/abstraction/AbstractionGraphComponent.java
@@ -11,9 +11,9 @@ import java.util.List;
 public abstract class AbstractionGraphComponent {
 
     /***
-     * List of synonyms used, on the graph query language, to reference edges of this edge type.
+     * List of types used, on the graph query language, to reference edges of this edge type.
      */
-    protected List<String> synonyms = new ArrayList<>();
+    protected List<String> types = new ArrayList<>();
 
     /***
      * List of of attributes, that an edge of this edge type, can be queried on.
@@ -21,17 +21,17 @@ public abstract class AbstractionGraphComponent {
     protected List<String> attributes = new ArrayList<>();
 
     /**
-     * @return the synonyms
+     * @return the types
      */
-    public List<String> getSynonyms() {
-        return synonyms;
+    public List<String> getTypes() {
+        return types;
     }
 
     /**
-     * @param synonyms the synonyms to set
+     * @param types the types to set
      */
-    public void setSynonyms(final List<String> synonyms) {
-        this.synonyms = synonyms;
+    public void setTypes(final List<String> types) {
+        this.types = types;
     }
 
     /**

--- a/common/src/main/java/org/cytosm/common/gtop/abstraction/AbstractionNode.java
+++ b/common/src/main/java/org/cytosm/common/gtop/abstraction/AbstractionNode.java
@@ -14,18 +14,18 @@ public class AbstractionNode extends AbstractionGraphComponent {
      * Generates an empty abstraction node.
      */
     public AbstractionNode() {
-        synonyms = new ArrayList<String>();
+        types = new ArrayList<String>();
         attributes = new ArrayList<String>();
     }
 
     /**
      * Generates an abstraction node using arguments.
      *
-     * @param synonyms synonyms used for the node
+     * @param types Nodes types used for the node
      * @param attributes attributes of that node
      */
-    public AbstractionNode(final List<String> synonyms, final List<String> attributes) {
-        this.synonyms = synonyms;
+    public AbstractionNode(final List<String> types, final List<String> attributes) {
+        this.types = types;
         this.attributes = attributes;
     }
 
@@ -33,10 +33,10 @@ public class AbstractionNode extends AbstractionGraphComponent {
     @SuppressWarnings("checkstyle:magicnumber")
     public int hashCode() {
         // In order to produce the same hash-code.
-        Collections.sort(synonyms);
+        Collections.sort(types);
         Collections.sort(attributes);
 
-        int result = synonyms != null ? synonyms.hashCode() : 0;
+        int result = types != null ? types.hashCode() : 0;
         result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
         return result;
     }

--- a/common/src/main/java/org/cytosm/common/gtop/implementation/relational/ImplementationEdge.java
+++ b/common/src/main/java/org/cytosm/common/gtop/implementation/relational/ImplementationEdge.java
@@ -14,9 +14,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class ImplementationEdge {
 
     /***
-     * Names that this edge may be references on the abstraction level.
+     * Node types that this edge may be referenced on the abstraction level.
      */
-    private List<String> synonyms = new ArrayList<>();
+    private List<String> types = new ArrayList<>();
 
     /***
      * The path is a list of all the tables, that at the end would model analogous property graph's edges.
@@ -25,11 +25,11 @@ public class ImplementationEdge {
 
     /***
      * Generates an Implementation edge.
-     * @param synonyms synonyms used to refer to that edge on the abstraction level
+     * @param types types used to refer to that edge on the abstraction level
      * @param paths traversal paths that compose that edge
      */
-    public ImplementationEdge(final List<String> synonyms, final List<TraversalPath> paths) {
-        this.synonyms = synonyms;
+    public ImplementationEdge(final List<String> types, final List<TraversalPath> paths) {
+        this.types = types;
         this.paths = paths;
     }
 
@@ -40,7 +40,7 @@ public class ImplementationEdge {
     public ImplementationEdge() {
 
         paths = new ArrayList<>();
-        synonyms = new ArrayList<>();
+        types = new ArrayList<>();
 
         TraversalPath traversalPath = new TraversalPath();
         TraversalHop traversalHop = new TraversalHop();
@@ -55,17 +55,17 @@ public class ImplementationEdge {
     }
 
     /**
-     * @return the synonyms
+     * @return the types
      */
-    public List<String> getSynonyms() {
-        return synonyms;
+    public List<String> getTypes() {
+        return types;
     }
 
     /**
-     * @param synonyms the synonyms to set
+     * @param types the types to set
      */
-    public void setSynonyms(final List<String> synonyms) {
-        this.synonyms = synonyms;
+    public void setTypes(final List<String> types) {
+        this.types = types;
     }
 
     /**
@@ -85,7 +85,7 @@ public class ImplementationEdge {
     @Override
     @SuppressWarnings("checkstyle:magicnumber")
     public int hashCode() {
-        int result = synonyms != null ? synonyms.hashCode() : 0;
+        int result = types != null ? types.hashCode() : 0;
         result = 31 * result + (paths != null ? paths.hashCode() : 0);
         return result;
     }
@@ -101,10 +101,10 @@ public class ImplementationEdge {
 
         final ImplementationEdge that = (ImplementationEdge) o;
 
-        List<String> thatSynonyms = that.getSynonyms();
+        List<String> thatType = that.getTypes();
         List<TraversalPath> thatPaths = that.getPaths();
 
-        if (!synonyms.containsAll(thatSynonyms) || !thatSynonyms.containsAll(synonyms)) {
+        if (!types.containsAll(thatType) || !thatType.containsAll(types)) {
             return false;
         }
         if (!paths.containsAll(thatPaths) || !thatPaths.containsAll(paths)) {

--- a/common/src/main/java/org/cytosm/common/gtop/implementation/relational/ImplementationNode.java
+++ b/common/src/main/java/org/cytosm/common/gtop/implementation/relational/ImplementationNode.java
@@ -10,9 +10,9 @@ import java.util.List;
 public class ImplementationNode {
 
     /***
-     * List of synonyms of tables, as used in graph query languages e.g. Cypher, Gremlin.
+     * List of types used to reference that node, as used in Graph Query Languages e.g. labels in Cypher.
      */
-    private List<String> synonyms = new ArrayList<>();
+    private List<String> types = new ArrayList<>();
 
     /***
      * Simple identifier for table name e.g. “person” or “ab-21-78”. This specifies the name of the
@@ -45,7 +45,7 @@ public class ImplementationNode {
      * Creates an empty implementation node.
      */
     public ImplementationNode() {
-        synonyms = new ArrayList<>();
+        types = new ArrayList<>();
         tableName = "";
         id = new ArrayList<>();
         attributes = new ArrayList<>();
@@ -54,15 +54,15 @@ public class ImplementationNode {
 
     /***
      * Generates an implementation Node.
-     * @param synonyms synonyms used on the abstraction level for this implementation Node
+     * @param types types used on the abstraction level for this implementation Node
      * @param tableName table where this node information comes from
      * @param id List of id items that compose the ID of that node
      * @param attributes list of attributes in that node
      * @param restrictions restrictions to assume that a tuple is a node of this type.
      */
-    public ImplementationNode(final List<String> synonyms, final String tableName, final List<NodeIdImplementation> id,
-            final List<Attribute> attributes, final List<RestrictionClauses> restrictions) {
-        this.synonyms = synonyms;
+    public ImplementationNode(final List<String> types, final String tableName, final List<NodeIdImplementation> id,
+                              final List<Attribute> attributes, final List<RestrictionClauses> restrictions) {
+        this.types = types;
         this.tableName = tableName;
         this.id = id;
         this.attributes = attributes;
@@ -81,10 +81,10 @@ public class ImplementationNode {
     }
 
     /**
-     * @param synonyms the synonyms to set
+     * @param types the types to set
      */
-    public void setSynonyms(final List<String> synonyms) {
-        this.synonyms = synonyms;
+    public void setTypes(final List<String> types) {
+        this.types = types;
     }
 
     /**
@@ -102,10 +102,10 @@ public class ImplementationNode {
     }
 
     /**
-     * @return the synonyms
+     * @return the types
      */
-    public List<String> getSynonyms() {
-        return synonyms;
+    public List<String> getTypes() {
+        return types;
     }
 
     /**

--- a/common/src/test/java/org/cytosm/common/GtopTest.java
+++ b/common/src/test/java/org/cytosm/common/GtopTest.java
@@ -125,16 +125,16 @@ public class GtopTest {
          * Restriction("tableName.columnName", "pattern"); restrictions.add(restriction);
          *
          * node.setAttributes(attributes); node.setTableName("tableName");
-         * node.setIdColumn("idColumn"); node.setSynonyms(labels);
+         * node.setIdColumn("idColumn"); node.setTypes(labels);
          * node.setRestrictions(restrictions); nodes.add(node);
          *
          * Edge edge = new Edge(); edge.setEdgeMappedTable("edgeTable");
          * edge.setDestinationTableColumn("destination"); edge.setSourceTableName("tableName");
-         * edge.setSourceTableColumn("columnName"); List<String> synonyms = new ArrayList<>();
-         * synonyms.add("myEdgeTable");
+         * edge.setSourceTableColumn("columnName"); List<String> types = new ArrayList<>();
+         * types.add("myEdgeTable");
          *//*
            *
-           * edge.setSynonyms(synonyms);
+           * edge.setTypes(types);
            *
            * edges.add(edge);
            */
@@ -164,28 +164,28 @@ public class GtopTest {
 
         // abstract edges:
 
-        Assert.assertEquals(gInterface.getAbstractionEdgesBySynonym("edge1").get(0).getDestinationType().get(0),
-                gInterfaceFromString.getAbstractionEdgesBySynonym("edge1").get(0).getDestinationType().get(0));
+        Assert.assertEquals(gInterface.getAbstractionEdgesByTypes("edge1").get(0).getDestinationType().get(0),
+                gInterfaceFromString.getAbstractionEdgesByTypes("edge1").get(0).getDestinationType().get(0));
 
-        Assert.assertEquals(gInterface.getAbstractionEdgesBySynonym("edge1").get(0).getSourceType().get(0),
-                gInterfaceFromString.getAbstractionEdgesBySynonym("edge1").get(0).getSourceType().get(0));
+        Assert.assertEquals(gInterface.getAbstractionEdgesByTypes("edge1").get(0).getSourceType().get(0),
+                gInterfaceFromString.getAbstractionEdgesByTypes("edge1").get(0).getSourceType().get(0));
 
-        Assert.assertEquals(gInterface.getAbstractionEdgesBySynonym("edge1").get(0).isDirected(), gInterfaceFromString
-                .getAbstractionEdgesBySynonym("edge1").get(0).isDirected());
+        Assert.assertEquals(gInterface.getAbstractionEdgesByTypes("edge1").get(0).isDirected(), gInterfaceFromString
+                .getAbstractionEdgesByTypes("edge1").get(0).isDirected());
 
-        Assert.assertEquals(gInterface.getAbstractionEdgesBySynonym("edge1").get(0).getSynonyms().get(0), gInterfaceFromString
-                .getAbstractionEdgesBySynonym("edge1").get(0).getSynonyms().get(0));
+        Assert.assertEquals(gInterface.getAbstractionEdgesByTypes("edge1").get(0).getTypes().get(0), gInterfaceFromString
+                .getAbstractionEdgesByTypes("edge1").get(0).getTypes().get(0));
 
-        AbstractionNode nod1 = gInterface.getAbstractionNodesBySynonym("node1").get(0);
-        AbstractionNode nod2 = gInterface.getAbstractionNodesBySynonym("node2").get(0);
+        AbstractionNode nod1 = gInterface.getAbstractionNodesByTypes("node1").get(0);
+        AbstractionNode nod2 = gInterface.getAbstractionNodesByTypes("node2").get(0);
 
         List<AbstractionNode> allNodes = gInterface.getAbstractionNodes();
         List<AbstractionNode> sourceNodes =
-                gInterface.getSourceNodesForEdge(gInterface.getAbstractionEdgesBySynonym("edge1").get(0));
+                gInterface.getSourceNodesForEdge(gInterface.getAbstractionEdgesByTypes("edge1").get(0));
         List<AbstractionNode> destinationNodes =
-                gInterface.getDestinationNodesForEdge(gInterface.getAbstractionEdgesBySynonym("edge1").get(0));
+                gInterface.getDestinationNodesForEdge(gInterface.getAbstractionEdgesByTypes("edge1").get(0));
         List<AbstractionNode> allNodesFromEdge =
-                gInterface.getNodesForEdge(gInterface.getAbstractionEdgesBySynonym("edge1").get(0));
+                gInterface.getNodesForEdge(gInterface.getAbstractionEdgesByTypes("edge1").get(0));
 
         Assert.assertTrue(allNodes.contains(nod1) && allNodes.contains(nod2));
         Assert.assertTrue(sourceNodes.contains(nod1) && sourceNodes.size() == 1);
@@ -196,11 +196,11 @@ public class GtopTest {
         //Assert.assertEquals(impedg1, impedg2);
 
         // abstract Nodes:
-        Assert.assertEquals(gInterface.getAbstractionNodesBySynonym("node1"),
-                gInterfaceFromString.getAbstractionNodesBySynonym("node1"));
+        Assert.assertEquals(gInterface.getAbstractionNodesByTypes("node1"),
+                gInterfaceFromString.getAbstractionNodesByTypes("node1"));
 
-        Assert.assertNotEquals(gInterface.getAbstractionNodesBySynonym("node1"),
-                gInterfaceFromString.getAbstractionNodesBySynonym("node2"));
+        Assert.assertNotEquals(gInterface.getAbstractionNodesByTypes("node1"),
+                gInterfaceFromString.getAbstractionNodesByTypes("node2"));
 
         //Assert.assertEquals(gTop.getAbstractionNodes(), gtopFromString.getAbstractionNodes());
 

--- a/cypher2sql/src/main/java/org/cytosm/cypher2sql/expandpaths/CypherConverter.java
+++ b/cypher2sql/src/main/java/org/cytosm/cypher2sql/expandpaths/CypherConverter.java
@@ -147,7 +147,7 @@ public class CypherConverter extends CanonicalConverter {
         }
 
         // Types
-        List<String> synonyms = edge.types.stream().map(t -> t.name).collect(Collectors.toList());
+        List<String> types = edge.types.stream().map(t -> t.name).collect(Collectors.toList());
 
         // Variable
         if (edge.variable.isPresent()) {
@@ -171,7 +171,7 @@ public class CypherConverter extends CanonicalConverter {
             }
         }
 
-        return new ExpansionEdge(synonyms, attributes, direction,
+        return new ExpansionEdge(types, attributes, direction,
                 minimumRange, maximumRange, matchall, variable);
     }
 
@@ -211,7 +211,7 @@ public class CypherConverter extends CanonicalConverter {
     private static ExpansionNode convertToAbstractionNode(NodePattern node) {
 
 
-        List<String> synonymsList = new ArrayList<>();
+        List<String> typesList = new ArrayList<>();
         Map<String, String> attributes = new HashMap<>();
 
         // This code is missing the point really. It does not support the all
@@ -228,7 +228,7 @@ public class CypherConverter extends CanonicalConverter {
 
         Iterator<LabelName> iter = node.labels.iterator();
         while (iter.hasNext()) {
-            synonymsList.add(iter.next().name);
+            typesList.add(iter.next().name);
         }
 
         String variable = "";
@@ -237,6 +237,6 @@ public class CypherConverter extends CanonicalConverter {
             variable = node.variable.get().name;
         }
 
-        return new ExpansionNode(synonymsList, attributes, variable);
+        return new ExpansionNode(typesList, attributes, variable);
     }
 }

--- a/cypher2sql/src/main/java/org/cytosm/cypher2sql/expandpaths/ExpandCypher.java
+++ b/cypher2sql/src/main/java/org/cytosm/cypher2sql/expandpaths/ExpandCypher.java
@@ -126,7 +126,7 @@ public final class ExpandCypher {
     }
 
     /**
-     * Takes a query, parses out all the synonyms and types, and if they aren't consistent it rejects it.
+     * Takes a query, parses out all the types, and if they aren't consistent it rejects it.
      *
      * @param query the query to validate
      */

--- a/cypher2sql/src/main/java/org/cytosm/cypher2sql/lowering/ExpandNodeVarWithGtop.java
+++ b/cypher2sql/src/main/java/org/cytosm/cypher2sql/lowering/ExpandNodeVarWithGtop.java
@@ -116,15 +116,15 @@ public class ExpandNodeVarWithGtop {
                             Comparator.comparing(ImplementationNode::getTableName)
                     );
 
-                    // Labels act as an AND. The ImplementationNodes found must have synonyms
+                    // Labels act as an AND. The ImplementationNodes found must have types
                     // for ALL the labels. So if we ask for 'message' and 'post', we will reject
-                    // the 'Comment' table because it does not satisfies the 'post' synonym.
+                    // the 'Comment' table because it does not satisfies the 'post' type.
                     for (String label: var.labels) {
-                        implNodes.addAll(gTopInterface.getImplementationNodesBySynonym(label));
+                        implNodes.addAll(gTopInterface.getImplementationNodesByType(label));
                     }
                     implNodes = implNodes.stream()
                             .filter(n -> var.labels.stream()
-                                    .allMatch(l -> n.getSynonyms().stream().anyMatch(s -> s.equalsIgnoreCase(l)))
+                                    .allMatch(l -> n.getTypes().stream().anyMatch(s -> s.equalsIgnoreCase(l)))
                             )
                             .collect(Collectors.toSet());
 

--- a/cypher2sql/src/main/java/org/cytosm/cypher2sql/lowering/PopulateJoins.java
+++ b/cypher2sql/src/main/java/org/cytosm/cypher2sql/lowering/PopulateJoins.java
@@ -130,7 +130,7 @@ public class PopulateJoins {
                 Var rightNode = rel.rightNode;
 
                 List<ImplementationEdge> edges = rel.labels.stream()
-                        .flatMap(l -> gTopInterface.getImplementationEdgeBySynonym(l).stream())
+                        .flatMap(l -> gTopInterface.getImplementationEdgeByType(l).stream())
                         .filter(edge -> {
                             TraversalHop hop = edge.getPaths().get(0).getTraversalHops().get(0);
                             return (hop.getSourceTableName().equals(leftNodeOriginTableName) &&

--- a/cypher2sql/src/main/java/org/cytosm/cypher2sql/lowering/TransformFunctions.java
+++ b/cypher2sql/src/main/java/org/cytosm/cypher2sql/lowering/TransformFunctions.java
@@ -137,7 +137,7 @@ public class TransformFunctions {
             var = AliasVar.resolveAliasVar(var);
             if (var instanceof NodeVar) {
                 NodeVar nodeVar = (NodeVar) var;
-                List<ImplementationNode> nodes = gtop.getImplementationNodesBySynonym(nodeVar.labels.get(0));
+                List<ImplementationNode> nodes = gtop.getImplementationNodesByType(nodeVar.labels.get(0));
                 // FIXME: We should make sure that we always have *exactly* one node returned here.
                 return nodes.get(0).getId().get(0).getColumnName();
             }

--- a/cypher2sql/src/test/resources/ldbc.gtop
+++ b/cypher2sql/src/test/resources/ldbc.gtop
@@ -2,179 +2,179 @@
 	"version": "1.0",
 	"abstractionLevel": {
 		"abstractionNodes": [{
-			"synonyms": ["person"],
+			"types": ["person"],
 			"attributes": ["id", "creationDate", "firstName", "lastName", "gender", "birthday", "browserUsed", "locationIP"]
 		}, {
-			"synonyms": ["university"],
+			"types": ["university"],
 			"attributes": ["id", "name"]
 		}, {
-			"synonyms": ["company"],
+			"types": ["company"],
 			"attributes": ["id", "name"]
 		}, {
-			"synonyms": ["city"],
+			"types": ["city"],
 			"attributes": ["id", "name"]
 		}, {
-			"synonyms": ["country"],
+			"types": ["country"],
 			"attributes": ["id", "name"]
 		}, {
-			"synonyms": ["continent"],
+			"types": ["continent"],
 			"attributes": ["id", "name"]
 		}, {
-			"synonyms": ["comment", "message"],
+			"types": ["comment", "message"],
 			"attributes": ["id", "creationDate", "browserUsed", "locationIP", "content", "length"]
 		}, {
-			"synonyms": ["post", "message"],
+			"types": ["post", "message"],
 			"attributes": ["id", "creationDate", "browserUsed", "locationIP", "content", "length", "language", "imageFile"]
 		}, {
-			"synonyms": ["forum"],
+			"types": ["forum"],
 			"attributes": ["id", "title", "creationDate"]
 		}, {
-			"synonyms": ["tag"],
+			"types": ["tag"],
 			"attributes": ["id", "name"]
 		}, {
-			"synonyms": ["tagclass"],
+			"types": ["tagclass"],
 			"attributes": ["id", "name"]
 		}],
 		"abstractionEdges": [{
-			"synonyms": ["knows"],
+			"types": ["knows"],
 			"attributes": ["creationDate"],
 			"sourceType": ["person"],
 			"destinationType": ["person"],
 			"directed": true
 		}, {
-			"synonyms": ["has_interest"],
+			"types": ["has_interest"],
 			"attributes": [],
 			"sourceType": ["person"],
 			"destinationType": ["tag"],
 			"directed": true
 		}, {
-			"synonyms": ["has_type"],
+			"types": ["has_type"],
 			"attributes": [],
 			"sourceType": ["tag"],
 			"destinationType": ["tagclass"],
 			"directed": true
 		}, {
-			"synonyms": ["has_moderator"],
+			"types": ["has_moderator"],
 			"attributes": [],
 			"sourceType": ["forum"],
 			"destinationType": ["person"],
 			"directed": true
 		}, {
-			"synonyms": ["has_member"],
+			"types": ["has_member"],
 			"attributes": ["joinDate"],
 			"sourceType": ["forum"],
 			"destinationType": ["person"],
 			"directed": true
 		}, {
-			"synonyms": ["container_of"],
+			"types": ["container_of"],
 			"attributes": [],
 			"sourceType": ["forum"],
 			"destinationType": ["post"],
 			"directed": true
 		}, {
-			"synonyms": ["has_tag"],
+			"types": ["has_tag"],
 			"attributes": [],
 			"sourceType": ["post"],
 			"destinationType": ["tag"],
 			"directed": true
 		}, {
-			"synonyms": ["has_tag"],
+			"types": ["has_tag"],
 			"attributes": [],
 			"sourceType": ["comment"],
 			"destinationType": ["tag"],
 			"directed": true
 		},{
-			"synonyms": ["is_subclass_of"],
+			"types": ["is_subclass_of"],
 			"attributes": [],
 			"sourceType": ["tagclass"],
 			"destinationType": ["tagclass"],
 			"directed": true
 		}, {
-			"synonyms": ["has_creator"],
+			"types": ["has_creator"],
 			"attributes": [],
 			"sourceType": ["post"],
 			"destinationType": ["person"],
 			"directed": true
 		}, {
-			"synonyms": ["has_creator"],
+			"types": ["has_creator"],
 			"attributes": [],
 			"sourceType": ["comment"],
 			"destinationType": ["person"],
 			"directed": true
 		}, {
-			"synonyms": ["likes"],
+			"types": ["likes"],
 			"attributes": ["creationDate"],
 			"sourceType": ["person"],
 			"destinationType": ["post"],
 			"directed": true
 		},{
-			"synonyms": ["likes"],
+			"types": ["likes"],
 			"attributes": ["creationDate"],
 			"sourceType": ["person"],
 			"destinationType": ["comment"],
 			"directed": true
 		}, {
-			"synonyms": ["reply_of"],
+			"types": ["reply_of"],
 			"attributes": [],
 			"sourceType": ["comment"],
 			"destinationType": ["post"],
 			"directed": true
 		},{
-			"synonyms": ["reply_of"],
+			"types": ["reply_of"],
 			"attributes": [],
 			"sourceType": ["comment"],
 			"destinationType": ["comment"],
 			"directed": true
 		}, {
-			"synonyms": ["is_located_in"],
+			"types": ["is_located_in"],
 			"attributes": [],
 			"sourceType": ["post"],
 			"destinationType": ["country"],
 			"directed": true
 		}, {
-			"synonyms": ["is_located_in"],
+			"types": ["is_located_in"],
 			"attributes": [],
 			"sourceType": ["comment"],
 			"destinationType": ["country"],
 			"directed": true
 		}, {
-			"synonyms": ["works_at"],
+			"types": ["works_at"],
 			"attributes": ["workFrom"],
 			"sourceType": ["person"],
 			"destinationType": ["company"],
 			"directed": true
 		}, {
-			"synonyms": ["study_at"],
+			"types": ["study_at"],
 			"attributes": ["classYear"],
 			"sourceType": ["person"],
 			"destinationType": ["university"],
 			"directed": true
 		}, {
-			"synonyms": ["is_located_in"],
+			"types": ["is_located_in"],
 			"attributes": [],
 			"sourceType": ["university"],
 			"destinationType": ["city"],
 			"directed": true
 		}, {
-			"synonyms": ["is_located_in"],
+			"types": ["is_located_in"],
 			"attributes": [],
 			"sourceType": ["company"],
 			"destinationType": ["country"],
 			"directed": true
 		}, {
-			"synonyms": ["is_located_in"],
+			"types": ["is_located_in"],
 			"attributes": [],
 			"sourceType": ["person"],
 			"destinationType": ["city"],
 			"directed": true
 		}, {
-			"synonyms": ["is_part_of"],
+			"types": ["is_part_of"],
 			"attributes": [],
 			"sourceType": ["city"],
 			"destinationType": ["country"],
 			"directed": true
 		}, {
-			"synonyms": ["is_part_of"],
+			"types": ["is_part_of"],
 			"attributes": [],
 			"sourceType": ["country"],
 			"destinationType": ["continent"],
@@ -186,7 +186,7 @@
 			"storageLayout": "IGNORETIME"
 		},
 		"implementationNodes": [{
-			"synonyms": ["Person"],
+			"types": ["Person"],
 			"tableName": "Person",
 			"id": [{
 				"columnName": "id",
@@ -224,7 +224,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["university"],
+			"types": ["university"],
 			"tableName": "University",
 			"id": [{
 				"columnName": "id",
@@ -238,7 +238,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["company"],
+			"types": ["company"],
 			"tableName": "Company",
 			"id": [{
 				"columnName": "id",
@@ -252,7 +252,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["city"],
+			"types": ["city"],
 			"tableName": "City",
 			"id": [{
 				"columnName": "id",
@@ -266,7 +266,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["country"],
+			"types": ["country"],
 			"tableName": "Country",
 			"id": [{
 				"columnName": "id",
@@ -280,7 +280,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["continent"],
+			"types": ["continent"],
 			"tableName": "Continent",
 			"id": [{
 				"columnName": "id",
@@ -294,7 +294,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["forum"],
+			"types": ["forum"],
 			"tableName": "Forum",
 			"id": [{
 				"columnName": "id",
@@ -312,7 +312,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["tag"],
+			"types": ["tag"],
 			"tableName": "Tag",
 			"id": [{
 				"columnName": "id",
@@ -326,7 +326,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["tagclass"],
+			"types": ["tagclass"],
 			"tableName": "TagClass",
 			"id": [{
 				"columnName": "id",
@@ -340,7 +340,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["post", "message"],
+			"types": ["post", "message"],
 			"tableName": "Post",
 			"id": [{
 				"columnName": "id",
@@ -378,7 +378,7 @@
 			}],
 			"restrictions": []
 		}, {
-			"synonyms": ["comment", "message"],
+			"types": ["comment", "message"],
 			"tableName": "Comment",
 			"id": [{
 				"columnName": "id",
@@ -409,7 +409,7 @@
 			"restrictions": []
 		}],
 		"implementationEdges": [{
-				"synonyms": ["knows"],
+				"types": ["knows"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",
@@ -427,7 +427,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["has_interest"],
+				"types": ["has_interest"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",
@@ -441,7 +441,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["has_moderator"],
+				"types": ["has_moderator"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Forum",
@@ -457,7 +457,7 @@
 			},
 
 			{
-				"synonyms": ["has_member"],
+				"types": ["has_member"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Forum",
@@ -477,7 +477,7 @@
 			},
 
 			{
-				"synonyms": ["likes"],
+				"types": ["likes"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",
@@ -496,7 +496,7 @@
 				}]
 			},
 			{
-				"synonyms": ["likes"],
+				"types": ["likes"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",
@@ -515,7 +515,7 @@
 				}]
 			},
 			{
-				"synonyms": ["has_type"],
+				"types": ["has_type"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Tag",
@@ -529,7 +529,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["is_subclass_of"],
+				"types": ["is_subclass_of"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "TagClass",
@@ -543,7 +543,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["has_creator"],
+				"types": ["has_creator"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Post",
@@ -557,7 +557,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["has_creator"],
+				"types": ["has_creator"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Comment",
@@ -571,7 +571,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["is_located_in"],
+				"types": ["is_located_in"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Comment",
@@ -585,7 +585,7 @@
 					}]
 				}]
 			},{
-				"synonyms": ["is_located_in"],
+				"types": ["is_located_in"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Post",
@@ -599,7 +599,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["reply_of"],
+				"types": ["reply_of"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Comment",
@@ -613,7 +613,7 @@
 					}]
 				}]
 			},  {
-				"synonyms": ["reply_of"],
+				"types": ["reply_of"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Comment",
@@ -627,7 +627,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["has_tag"],
+				"types": ["has_tag"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Post",
@@ -641,7 +641,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["has_tag"],
+				"types": ["has_tag"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Comment",
@@ -655,7 +655,7 @@
 					}]
 				}]
 			},{
-				"synonyms": ["is_located_in"],
+				"types": ["is_located_in"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Company",
@@ -669,7 +669,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["is_located_in"],
+				"types": ["is_located_in"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "University",
@@ -685,7 +685,7 @@
 			},
 
 			{
-				"synonyms": ["is_part_of"],
+				"types": ["is_part_of"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "City",
@@ -701,7 +701,7 @@
 			},
 
 			{
-				"synonyms": ["is_part_of"],
+				"types": ["is_part_of"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Country",
@@ -717,7 +717,7 @@
 			},
 
 			{
-				"synonyms": ["is_located_in"],
+				"types": ["is_located_in"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",
@@ -731,7 +731,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["works_at"],
+				"types": ["works_at"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",
@@ -751,7 +751,7 @@
 					}]
 				}]
 			}, {
-				"synonyms": ["study_at"],
+				"types": ["study_at"],
 				"paths": [{
 					"traversalHops": [{
 						"sourceTableName": "Person",

--- a/cypher2sql/src/test/resources/movies.gtop
+++ b/cypher2sql/src/test/resources/movies.gtop
@@ -2,26 +2,26 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "attributes" : [ "id", "title", "released", "tagline" ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "attributes" : [ "id", "name", "born" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "attributes" : [ "role" ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
@@ -33,7 +33,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "tableName" : "movie",
       "id" : [ {
         "columnName" : "id",
@@ -59,7 +59,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "tableName" : "person",
       "id" : [ {
         "columnName" : "id",
@@ -82,7 +82,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -96,7 +96,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -114,7 +114,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",

--- a/cypher2sql/src/test/resources/northwind.gtop
+++ b/cypher2sql/src/test/resources/northwind.gtop
@@ -2,116 +2,116 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "shippers" ],
+      "types" : [ "shippers" ],
       "attributes" : [ "ShipperID", "CompanyName", "Phone" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "regions" ],
+      "types" : [ "regions" ],
       "attributes" : [ "RegionID", "RegionDescription" ]
     }, {
-      "synonyms" : [ "territories" ],
+      "types" : [ "territories" ],
       "attributes" : [ "TerritoryID", "TerritoryDescription" ]
     }, {
-      "synonyms" : [ "customerdemographics" ],
+      "types" : [ "customerdemographics" ],
       "attributes" : [ "CustomerTypeID", "CustomerDesc" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "customerid_orders_employeeid" ],
+      "types" : [ "customerid_orders_employeeid" ],
       "attributes" : [ "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ],
       "sourceType" : [ "Customers" ],
       "destinationType" : [ "Employees" ],
       "directed" : false
     }, {
-      "synonyms" : [ "employeeid_orders_shipvia" ],
+      "types" : [ "employeeid_orders_shipvia" ],
       "attributes" : [ "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ],
       "sourceType" : [ "Employees" ],
       "destinationType" : [ "Shippers" ],
       "directed" : false
     }, {
-      "synonyms" : [ "customerid_orders_shipvia" ],
+      "types" : [ "customerid_orders_shipvia" ],
       "attributes" : [ "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ],
       "sourceType" : [ "Customers" ],
       "destinationType" : [ "Shippers" ],
       "directed" : false
     }, {
-      "synonyms" : [ "employees_employeeid_orders_employeeid" ],
+      "types" : [ "employees_employeeid_orders_employeeid" ],
       "attributes" : [ ],
       "sourceType" : [ "Orders" ],
       "destinationType" : [ "Employees" ],
       "directed" : false
     }, {
-      "synonyms" : [ "customers_customerid_orders_customerid" ],
+      "types" : [ "customers_customerid_orders_customerid" ],
       "attributes" : [ ],
       "sourceType" : [ "Orders" ],
       "destinationType" : [ "Customers" ],
       "directed" : false
     }, {
-      "synonyms" : [ "shipvia_shipvia_shippers_shipperid" ],
+      "types" : [ "shipvia_shipvia_shippers_shipperid" ],
       "attributes" : [ ],
       "sourceType" : [ "Orders" ],
       "destinationType" : [ "Shippers" ],
       "directed" : false
     }, {
-      "synonyms" : [ "categoryid_products_supplierid" ],
+      "types" : [ "categoryid_products_supplierid" ],
       "attributes" : [ "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ],
       "sourceType" : [ "Categories" ],
       "destinationType" : [ "Suppliers" ],
       "directed" : false
     }, {
-      "synonyms" : [ "categories_categoryid_products_categoryid" ],
+      "types" : [ "categories_categoryid_products_categoryid" ],
       "attributes" : [ ],
       "sourceType" : [ "Products" ],
       "destinationType" : [ "Categories" ],
       "directed" : false
     }, {
-      "synonyms" : [ "supplierid_supplierid_suppliers_supplierid" ],
+      "types" : [ "supplierid_supplierid_suppliers_supplierid" ],
       "attributes" : [ ],
       "sourceType" : [ "Products" ],
       "destinationType" : [ "Suppliers" ],
       "directed" : false
     }, {
-      "synonyms" : [ "employees_employeeid_employees_reportsto" ],
+      "types" : [ "employees_employeeid_employees_reportsto" ],
       "attributes" : [ ],
       "sourceType" : [ "Employees" ],
       "destinationType" : [ "Employees" ],
       "directed" : false
     }, {
-      "synonyms" : [ "regions_regionid_territories_regionid" ],
+      "types" : [ "regions_regionid_territories_regionid" ],
       "attributes" : [ ],
       "sourceType" : [ "Territories" ],
       "destinationType" : [ "Regions" ],
       "directed" : false
     }, {
-      "synonyms" : [ "customerid_customercustomerdemo_customerid" ],
+      "types" : [ "customerid_customercustomerdemo_customerid" ],
       "attributes" : [ ],
       "sourceType" : [ "Customers" ],
       "destinationType" : [ "CustomerDemographics" ],
       "directed" : false
     }, {
-      "synonyms" : [ "employeeid_employeeterritories_employeeid" ],
+      "types" : [ "employeeid_employeeterritories_employeeid" ],
       "attributes" : [ ],
       "sourceType" : [ "Employees" ],
       "destinationType" : [ "Territories" ],
       "directed" : false
     }, {
-      "synonyms" : [ "orderid_orderdetails_orderid" ],
+      "types" : [ "orderid_orderdetails_orderid" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "Orders" ],
       "destinationType" : [ "Products" ],
@@ -123,7 +123,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -177,7 +177,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -219,7 +219,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -245,7 +245,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "shippers" ],
+      "types" : [ "shippers" ],
       "tableName" : "Shippers",
       "id" : [ {
         "columnName" : "ShipperID",
@@ -267,7 +267,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -345,7 +345,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "regions" ],
+      "types" : [ "regions" ],
       "tableName" : "Regions",
       "id" : [ {
         "columnName" : "RegionID",
@@ -363,7 +363,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "territories" ],
+      "types" : [ "territories" ],
       "tableName" : "Territories",
       "id" : [ {
         "columnName" : "TerritoryID",
@@ -381,7 +381,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customerdemographics" ],
+      "types" : [ "customerdemographics" ],
       "tableName" : "CustomerDemographics",
       "id" : [ {
         "columnName" : "CustomerTypeID",
@@ -399,7 +399,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -457,7 +457,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -512,7 +512,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "customerid_orders_employeeid" ],
+      "types" : [ "customerid_orders_employeeid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -566,7 +566,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "employeeid_orders_shipvia" ],
+      "types" : [ "employeeid_orders_shipvia" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -620,7 +620,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "customerid_orders_shipvia" ],
+      "types" : [ "customerid_orders_shipvia" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -674,7 +674,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "employees_employeeid_orders_employeeid" ],
+      "types" : [ "employees_employeeid_orders_employeeid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",
@@ -688,7 +688,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "customers_customerid_orders_customerid" ],
+      "types" : [ "customers_customerid_orders_customerid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",
@@ -702,7 +702,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "shipvia_shipvia_shippers_shipperid" ],
+      "types" : [ "shipvia_shipvia_shippers_shipperid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",
@@ -716,7 +716,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "categoryid_products_supplierid" ],
+      "types" : [ "categoryid_products_supplierid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Categories",
@@ -758,7 +758,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "categories_categoryid_products_categoryid" ],
+      "types" : [ "categories_categoryid_products_categoryid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -772,7 +772,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "supplierid_supplierid_suppliers_supplierid" ],
+      "types" : [ "supplierid_supplierid_suppliers_supplierid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -786,7 +786,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "employees_employeeid_employees_reportsto" ],
+      "types" : [ "employees_employeeid_employees_reportsto" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -800,7 +800,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "regions_regionid_territories_regionid" ],
+      "types" : [ "regions_regionid_territories_regionid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Territories",
@@ -814,7 +814,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "customerid_customercustomerdemo_customerid" ],
+      "types" : [ "customerid_customercustomerdemo_customerid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -828,7 +828,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "employeeid_employeeterritories_employeeid" ],
+      "types" : [ "employeeid_employeeterritories_employeeid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -842,7 +842,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "orderid_orderdetails_orderid" ],
+      "types" : [ "orderid_orderdetails_orderid" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",

--- a/cypher2sql/src/test/resources/northwindDirect.gtop
+++ b/cypher2sql/src/test/resources/northwindDirect.gtop
@@ -2,50 +2,50 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "sold" ],
+      "types" : [ "sold" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "purchased" ],
+      "types" : [ "purchased" ],
       "attributes" : [ ],
       "sourceType" : [ "customers" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "part_of" ],
+      "types" : [ "part_of" ],
       "attributes" : [ ],
       "sourceType" : [ "products" ],
       "destinationType" : [ "categories" ],
       "directed" : true
     }, {
-      "synonyms" : [ "reports_to" ],
+      "types" : [ "reports_to" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "employees" ],
       "directed" : true
     }, {
-      "synonyms" : [ "product" ],
+      "types" : [ "product" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "orders" ],
       "destinationType" : [ "products" ],
@@ -57,7 +57,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -111,7 +111,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -153,7 +153,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -179,7 +179,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -257,7 +257,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -315,7 +315,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -370,7 +370,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "SOLD" ],
+      "types" : [ "SOLD" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -384,7 +384,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PURCHASED" ],
+      "types" : [ "PURCHASED" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -398,7 +398,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PART_OF" ],
+      "types" : [ "PART_OF" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -412,7 +412,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "SUPPLIES" ],
+      "types" : [ "SUPPLIES" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Suppliers",
@@ -426,7 +426,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "REPORTS_TO" ],
+      "types" : [ "REPORTS_TO" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -440,7 +440,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PRODUCT" ],
+      "types" : [ "PRODUCT" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",

--- a/cypher2sql/src/test/resources/northwindDirectAndUndirect.gtop
+++ b/cypher2sql/src/test/resources/northwindDirectAndUndirect.gtop
@@ -2,50 +2,50 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "sold" ],
+      "types" : [ "sold" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "purchased" ],
+      "types" : [ "purchased" ],
       "attributes" : [ ],
       "sourceType" : [ "customers" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "part_of" ],
+      "types" : [ "part_of" ],
       "attributes" : [ ],
       "sourceType" : [ "products" ],
       "destinationType" : [ "categories" ],
       "directed" : true
     }, {
-      "synonyms" : [ "reports_to" ],
+      "types" : [ "reports_to" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "employees" ],
       "directed" : true
     }, {
-      "synonyms" : [ "product" ],
+      "types" : [ "product" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "orders" ],
       "destinationType" : [ "products" ],
@@ -57,7 +57,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -111,7 +111,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -153,7 +153,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -179,7 +179,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -257,7 +257,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -315,7 +315,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -370,7 +370,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "SOLD" ],
+      "types" : [ "SOLD" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -384,7 +384,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PURCHASED" ],
+      "types" : [ "PURCHASED" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -398,7 +398,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PART_OF" ],
+      "types" : [ "PART_OF" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -412,7 +412,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "SUPPLIES" ],
+      "types" : [ "SUPPLIES" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Suppliers",
@@ -426,7 +426,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "REPORTS_TO" ],
+      "types" : [ "REPORTS_TO" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -440,7 +440,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PRODUCT" ],
+      "types" : [ "PRODUCT" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",

--- a/cypher2sql/src/test/resources/northwindUndirect.gtop
+++ b/cypher2sql/src/test/resources/northwindUndirect.gtop
@@ -1,51 +1,51 @@
-{
+s{
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "sold" ],
+      "types" : [ "sold" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "orders" ],
       "directed" : false
     }, {
-      "synonyms" : [ "purchased" ],
+      "types" : [ "purchased" ],
       "attributes" : [ ],
       "sourceType" : [ "customers" ],
       "destinationType" : [ "orders" ],
       "directed" : false
     }, {
-      "synonyms" : [ "part_of" ],
+      "types" : [ "part_of" ],
       "attributes" : [ ],
       "sourceType" : [ "products" ],
       "destinationType" : [ "categories" ],
       "directed" : false
     }, {
-      "synonyms" : [ "reports_to" ],
+      "types" : [ "reports_to" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "employees" ],
       "directed" : false
     }, {
-      "synonyms" : [ "product" ],
+      "types" : [ "product" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "orders" ],
       "destinationType" : [ "products" ],
@@ -57,7 +57,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -111,7 +111,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -153,7 +153,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -179,7 +179,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -257,7 +257,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -315,7 +315,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -370,7 +370,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "SOLD" ],
+      "types" : [ "SOLD" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -384,7 +384,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PURCHASED" ],
+      "types" : [ "PURCHASED" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -398,7 +398,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PART_OF" ],
+      "types" : [ "PART_OF" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -412,7 +412,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "SUPPLIES" ],
+      "types" : [ "SUPPLIES" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Suppliers",
@@ -426,7 +426,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "REPORTS_TO" ],
+      "types" : [ "REPORTS_TO" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -440,7 +440,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PRODUCT" ],
+      "types" : [ "PRODUCT" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",

--- a/pathfinder/src/main/java/org/cytosm/pathfinder/enumerators/AbstractEnumerator.java
+++ b/pathfinder/src/main/java/org/cytosm/pathfinder/enumerators/AbstractEnumerator.java
@@ -147,8 +147,8 @@ public abstract class AbstractEnumerator {
              * object.
              */
             if (element.getMatchedGtopAbstractionEntities().isEmpty()) {
-                if (!element.getSynonyms().isEmpty()) {
-                    solveSynonymsHint(element);
+                if (!element.getTypes().isEmpty()) {
+                    solveTypesHint(element);
                 }
 
                 // there are also attribute hints:
@@ -160,7 +160,7 @@ public abstract class AbstractEnumerator {
     }
 
     /***
-     * Solves matching Gtop candidates based on attributes, not on labels/synonyms.
+     * Solves matching Gtop candidates based on attributes, not on labels/types.
      *
      * @param element
      * @throws PathDescriptionException
@@ -168,7 +168,7 @@ public abstract class AbstractEnumerator {
     private void solveAttributesHint(final ExpansionElement element) throws PathDescriptionException {
 
         /***
-         * Should results were found when looking for synonyms, the attributes need to match what
+         * Should results were found when looking for types, the attributes need to match what
          * was found
          */
         boolean matchWithPreviousResult = !element.getMatchedGtopAbstractionEntities().isEmpty();
@@ -188,9 +188,9 @@ public abstract class AbstractEnumerator {
                  */
                 if (matchingEdge.isEmpty()) {
                     throw new PathDescriptionException(
-                            element.getSynonyms().toString() + element.getAttributeMap().keySet().toString());
+                            element.getTypes().toString() + element.getAttributeMap().keySet().toString());
                 } else {
-                    // The synonyms do not match the attribute list!
+                    // The types do not match the attribute list!
                     if (matchWithPreviousResult
                             && !element.getMatchedGtopAbstractionEntities().containsAll(matchingEdge)) {
 
@@ -207,11 +207,11 @@ public abstract class AbstractEnumerator {
 
                         if (!congruentAttributesWithLabels) {
                             // String str = matchingEdge.stream().map(list ->
-                            // list.getSynonyms()).map(Object::toString)
+                            // list.getTypes()).map(Object::toString)
                             // .collect(Collectors.joining(", "));
 
                             throw new PathDescriptionException(
-                                    element.getSynonyms().toString() + element.getAttributeMap().keySet().toString());
+                                    element.getTypes().toString() + element.getAttributeMap().keySet().toString());
                         }
                         // Otherwise just don't add anything - keeps the original match.
 
@@ -232,10 +232,10 @@ public abstract class AbstractEnumerator {
                 if (matchingNode.isEmpty()) {
 
                     throw new PathDescriptionException(
-                            element.getSynonyms().toString() + element.getAttributeMap().keySet().toString());
+                            element.getTypes().toString() + element.getAttributeMap().keySet().toString());
                 } else {
 
-                    // The synonyms do not match the attribute list!
+                    // The types do not match the attribute list!
                     if (matchWithPreviousResult
                             && !element.getMatchedGtopAbstractionEntities().containsAll(matchingNode)) {
 
@@ -252,7 +252,7 @@ public abstract class AbstractEnumerator {
 
                         if (!congruentAttributesWithLabels) {
                             throw new PathDescriptionException(
-                                    element.getSynonyms().toString() + element.getAttributeMap().keySet().toString());
+                                    element.getTypes().toString() + element.getAttributeMap().keySet().toString());
                         }
                         // Otherwise just don't add anything - keeps the original match.
                     } else {
@@ -321,29 +321,29 @@ public abstract class AbstractEnumerator {
 
 
     /***
-     * Search for Gtop Elements that matches the synonyms.
+     * Search for Gtop Elements that matches the types.
      *
      * @param element
      * @return if an element was found
      * @throws PathDescriptionException
      */
-    private void solveSynonymsHint(final ExpansionElement element) throws PathDescriptionException {
+    private void solveTypesHint(final ExpansionElement element) throws PathDescriptionException {
 
         List<AbstractionEdge> foundEquivalentEdge = null;
         List<AbstractionNode> foundEquivalentNode = null;
 
-        for (String synonym : element.getSynonyms()) {
+        for (String type : element.getTypes()) {
 
             if (!element.isNode()) {
                 // It's an edge
-                foundEquivalentEdge = gTopInter.getAbstractionEdgesBySynonym(synonym);
+                foundEquivalentEdge = gTopInter.getAbstractionEdgesByTypes(type);
                 if (foundEquivalentEdge != null) {
                     element.addMatchedGtopAbstractionEntities(
                             foundEquivalentEdge.stream().map(x -> x).collect(Collectors.toList()));
                 }
             } else {
                 // It's a node:
-                foundEquivalentNode = gTopInter.getAbstractionNodesBySynonym(synonym);
+                foundEquivalentNode = gTopInter.getAbstractionNodesByTypes(type);
 
                 if (foundEquivalentNode != null) {
                     element.addMatchedGtopAbstractionEntities(
@@ -351,10 +351,10 @@ public abstract class AbstractEnumerator {
                 }
             }
 
-            // wrong synonym given by the user on query time.
+            // wrong type given by the user on query time.
             if (foundEquivalentEdge == null && foundEquivalentNode == null) {
                 throw new PathDescriptionException(
-                        element.getSynonyms().toString() + element.getAttributeMap().keySet().toString());
+                        element.getTypes().toString() + element.getAttributeMap().keySet().toString());
             }
         }
     }
@@ -474,17 +474,17 @@ public abstract class AbstractEnumerator {
      */
     private boolean selfRelationshipsAllowed(final AbstractionNode currentNode, final AbstractionEdge edge,
             final List<AbstractionNode> nextNodeAbstractions) {
-        List<String> sourceSynonyms =
-                edge.getSourceType().stream().map(synonym -> synonym.toLowerCase()).collect(Collectors.toList());
-        List<String> destinationSynonyms =
-                edge.getDestinationType().stream().map(synonym -> synonym.toLowerCase()).collect(Collectors.toList());
-        List<String> currentNodeSynonyms =
-                currentNode.getSynonyms().stream().map(synonym -> synonym.toLowerCase()).collect(Collectors.toList());
+        List<String> sourceTypes =
+                edge.getSourceType().stream().map(type -> type.toLowerCase()).collect(Collectors.toList());
+        List<String> destinationTypes =
+                edge.getDestinationType().stream().map(type -> type.toLowerCase()).collect(Collectors.toList());
+        List<String> currentNodeTypes =
+                currentNode.getTypes().stream().map(type -> type.toLowerCase()).collect(Collectors.toList());
 
         boolean inBothLists = false;
 
-        if (sourceSynonyms.stream().anyMatch(node -> currentNodeSynonyms.contains(node))
-                && destinationSynonyms.stream().anyMatch(node -> currentNodeSynonyms.contains(node))) {
+        if (sourceTypes.stream().anyMatch(node -> currentNodeTypes.contains(node))
+                && destinationTypes.stream().anyMatch(node -> currentNodeTypes.contains(node))) {
             inBothLists = true;
         }
 
@@ -510,7 +510,7 @@ public abstract class AbstractEnumerator {
 
         // get abstract edges for given node.
         List<AbstractionEdge> possibleEdgesOnGtop =
-                gtopInter.getAllAbstractEdgesForNodeSynonms(currentNode.getSynonyms());
+                gtopInter.getAllAbstractEdgesForNodeTypes(currentNode.getTypes());
 
         // If next edge is undirected, add only undirected possibilities
         if (!routeEdge.isDirected()) {
@@ -540,10 +540,10 @@ public abstract class AbstractEnumerator {
 
                 if (routeEdge.isToRight()) {
                     // Then the current edge is pointing out of the current node
-                    return !Collections.disjoint(edge.getSourceType(), currentNode.getSynonyms());
+                    return !Collections.disjoint(edge.getSourceType(), currentNode.getTypes());
                 } else {
                     // then the current edge pointing in the current node
-                    return !Collections.disjoint(edge.getDestinationType(), currentNode.getSynonyms());
+                    return !Collections.disjoint(edge.getDestinationType(), currentNode.getTypes());
                 }
             }).collect(Collectors.toList());
         }

--- a/pathfinder/src/main/java/org/cytosm/pathfinder/output/PathSerializer.java
+++ b/pathfinder/src/main/java/org/cytosm/pathfinder/output/PathSerializer.java
@@ -31,7 +31,7 @@ public class PathSerializer implements Serializer {
                         sb.append(expansion.getVariable());
                     }
                     sb.append(":");
-                    sb.append(node.getSynonyms().get(0));
+                    sb.append(node.getTypes().get(0));
 
                     addAttributeMap(sb, expansion);
 
@@ -54,7 +54,7 @@ public class PathSerializer implements Serializer {
                     sb.append(expansion.getVariable());
                     sb.append(":");
                     AbstractionEdge edge = (AbstractionEdge) expansion.getEquivalentMaterializedGtop();
-                    sb.append(edge.getSynonyms().get(0));
+                    sb.append(edge.getTypes().get(0));
 
                     addAttributeMap(sb, expansion);
 

--- a/pathfinder/src/main/java/org/cytosm/pathfinder/routeelements/ExpansionEdge.java
+++ b/pathfinder/src/main/java/org/cytosm/pathfinder/routeelements/ExpansionEdge.java
@@ -51,13 +51,13 @@ public class ExpansionEdge extends ExpansionElement {
      * @param attributes attributes from the edge
      * @param cypherInformation additional edge information available in the cypher
      */
-    public ExpansionEdge(final List<String> synonyms, final Map<String, String> attributes,
+    public ExpansionEdge(final List<String> types, final Map<String, String> attributes,
                          final Direction direction, final OptionalLong minimumRange,
                          final OptionalLong maximumRange, final boolean matchall,
                          final Optional<String> variable) {
-        super(synonyms, attributes);
+        super(types, attributes);
 
-        if (!synonyms.isEmpty()) {
+        if (!types.isEmpty()) {
             hintAvailable = true;
         }
         if (direction.equals(Direction.Right) || direction.equals(Direction.Left)) {
@@ -90,7 +90,7 @@ public class ExpansionEdge extends ExpansionElement {
      * @param expansionEdge original expansion edge to be cloned
      */
     public ExpansionEdge(final ExpansionEdge expansionEdge) {
-        synonyms.addAll(expansionEdge.getSynonyms());
+        types.addAll(expansionEdge.getTypes());
 
         if (expansionEdge.directed) {
             directed = true;

--- a/pathfinder/src/main/java/org/cytosm/pathfinder/routeelements/ExpansionElement.java
+++ b/pathfinder/src/main/java/org/cytosm/pathfinder/routeelements/ExpansionElement.java
@@ -17,7 +17,7 @@ import org.cytosm.common.gtop.abstraction.AbstractionGraphComponent;
 public abstract class ExpansionElement {
 
     protected Map<String, String> attributeMap = new HashMap<>();
-    protected List<String> synonyms = new ArrayList<>();
+    protected List<String> types = new ArrayList<>();
 
     /***
      * possible gtop abstract entities that match the hints.
@@ -48,17 +48,17 @@ public abstract class ExpansionElement {
     /***
      * Default constructor.
      * 
-     * @param argSynonyms synonyms of the Expansion element
+     * @param argTypes types of the Expansion element
      * @param attributes Attributes of the expansion element
      */
-    public ExpansionElement(List<String> argSynonyms, Map<String, String> attributes) {
+    public ExpansionElement(List<String> argTypes, Map<String, String> attributes) {
         attributeMap = attributes;
-        this.synonyms.addAll(argSynonyms);
+        this.types.addAll(argTypes);
 
         /***
          * There are some hints provided by the user that restricts gtop possibilities
          */
-        if (!synonyms.isEmpty() || !attributes.isEmpty()) {
+        if (!types.isEmpty() || !attributes.isEmpty()) {
             hintAvailable = true;
         }
     }
@@ -102,17 +102,17 @@ public abstract class ExpansionElement {
     }
 
     /**
-     * @return the synonyms
+     * @return the types
      */
-    public List<String> getSynonyms() {
-        return synonyms;
+    public List<String> getTypes() {
+        return types;
     }
 
     /**
-     * @param synonyms the synonyms to set
+     * @param types the types to set
      */
-    public void setSynonyms(List<String> synonyms) {
-        this.synonyms = synonyms;
+    public void setTypes(List<String> types) {
+        this.types = types;
     }
 
     /***

--- a/pathfinder/src/main/java/org/cytosm/pathfinder/routeelements/ExpansionNode.java
+++ b/pathfinder/src/main/java/org/cytosm/pathfinder/routeelements/ExpansionNode.java
@@ -31,12 +31,12 @@ public class ExpansionNode extends ExpansionElement {
     /***
      * Default constructor.
      *
-     * @param synonyms node synonyms.
+     * @param types node types.
      * @param attributes attributes of the node
      * @param argVariable variables used to refer to given node
      */
-    public ExpansionNode(List<String> synonyms, Map<String, String> attributes, String argVariable) {
-        super(synonyms, attributes);
+    public ExpansionNode(List<String> types, Map<String, String> attributes, String argVariable) {
+        super(types, attributes);
         variable = argVariable;
     }
 
@@ -51,7 +51,7 @@ public class ExpansionNode extends ExpansionElement {
      * @param expansionNode original node
      */
     public ExpansionNode(ExpansionNode expansionNode) {
-        synonyms.addAll(expansionNode.getSynonyms());
+        types.addAll(expansionNode.getTypes());
         attributeMap = expansionNode.getAttributeMap();
         variable = expansionNode.getVariable();
     }
@@ -62,11 +62,11 @@ public class ExpansionNode extends ExpansionElement {
      * @return the anonymous node
      */
     public static ExpansionNode generateAnonymousNode() {
-        List<String> synonyms = new ArrayList<>();
+        List<String> types = new ArrayList<>();
         Map<String, String> attributes = new HashMap<>();
         String argVariable = null;
 
-        return new ExpansionNode(synonyms, attributes, argVariable);
+        return new ExpansionNode(types, attributes, argVariable);
     }
 
     /***

--- a/pathfinder/src/test/resources/movies.gtop
+++ b/pathfinder/src/test/resources/movies.gtop
@@ -2,26 +2,26 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "attributes" : [ "id", "title", "released", "tagline" ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "attributes" : [ "id", "name", "born" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "attributes" : [ "role" ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
       "directed" : true
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "attributes" : [ ],
       "sourceType" : [ "person" ],
       "destinationType" : [ "movie" ],
@@ -33,7 +33,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "movie" ],
+      "types" : [ "movie" ],
       "tableName" : "movie",
       "id" : [ {
         "columnName" : "id",
@@ -59,7 +59,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "person" ],
+      "types" : [ "person" ],
       "tableName" : "person",
       "id" : [ {
         "columnName" : "id",
@@ -82,7 +82,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "person_id_directed_person_id" ],
+      "types" : [ "person_id_directed_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -96,7 +96,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_acted_in_person_id" ],
+      "types" : [ "person_id_acted_in_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",
@@ -114,7 +114,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "person_id_produced_person_id" ],
+      "types" : [ "person_id_produced_person_id" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "person",

--- a/pathfinder/src/test/resources/northwindDirect.gtop
+++ b/pathfinder/src/test/resources/northwindDirect.gtop
@@ -2,50 +2,50 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "sold" ],
+      "types" : [ "sold" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "purchased" ],
+      "types" : [ "purchased" ],
       "attributes" : [ ],
       "sourceType" : [ "customers" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "part_of" ],
+      "types" : [ "part_of" ],
       "attributes" : [ ],
       "sourceType" : [ "products" ],
       "destinationType" : [ "categories" ],
       "directed" : true
     }, {
-      "synonyms" : [ "reports_to" ],
+      "types" : [ "reports_to" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "employees" ],
       "directed" : true
     }, {
-      "synonyms" : [ "product" ],
+      "types" : [ "product" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "orders" ],
       "destinationType" : [ "products" ],
@@ -57,7 +57,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -111,7 +111,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -153,7 +153,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -179,7 +179,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -257,7 +257,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -315,7 +315,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -370,7 +370,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "SOLD" ],
+      "types" : [ "SOLD" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -384,7 +384,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PURCHASED" ],
+      "types" : [ "PURCHASED" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -398,7 +398,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PART_OF" ],
+      "types" : [ "PART_OF" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -412,7 +412,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "SUPPLIES" ],
+      "types" : [ "SUPPLIES" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Suppliers",
@@ -426,7 +426,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "REPORTS_TO" ],
+      "types" : [ "REPORTS_TO" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -440,7 +440,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PRODUCT" ],
+      "types" : [ "PRODUCT" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",

--- a/pathfinder/src/test/resources/northwindDirectAndUndirect.gtop
+++ b/pathfinder/src/test/resources/northwindDirectAndUndirect.gtop
@@ -2,50 +2,50 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "sold" ],
+      "types" : [ "sold" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "purchased" ],
+      "types" : [ "purchased" ],
       "attributes" : [ ],
       "sourceType" : [ "customers" ],
       "destinationType" : [ "orders" ],
       "directed" : true
     }, {
-      "synonyms" : [ "part_of" ],
+      "types" : [ "part_of" ],
       "attributes" : [ ],
       "sourceType" : [ "products" ],
       "destinationType" : [ "categories" ],
       "directed" : true
     }, {
-      "synonyms" : [ "reports_to" ],
+      "types" : [ "reports_to" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "employees" ],
       "directed" : true
     }, {
-      "synonyms" : [ "product" ],
+      "types" : [ "product" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "orders" ],
       "destinationType" : [ "products" ],
@@ -57,7 +57,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -111,7 +111,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -153,7 +153,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -179,7 +179,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -257,7 +257,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -315,7 +315,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -370,7 +370,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "SOLD" ],
+      "types" : [ "SOLD" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -384,7 +384,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PURCHASED" ],
+      "types" : [ "PURCHASED" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -398,7 +398,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PART_OF" ],
+      "types" : [ "PART_OF" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -412,7 +412,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "SUPPLIES" ],
+      "types" : [ "SUPPLIES" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Suppliers",
@@ -426,7 +426,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "REPORTS_TO" ],
+      "types" : [ "REPORTS_TO" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -440,7 +440,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PRODUCT" ],
+      "types" : [ "PRODUCT" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",

--- a/pathfinder/src/test/resources/northwindUndirect.gtop
+++ b/pathfinder/src/test/resources/northwindUndirect.gtop
@@ -2,50 +2,50 @@
   "version" : "1.0",
   "abstractionLevel" : {
     "abstractionNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "attributes" : [ "OrderID", "OrderDate", "RequiredDate", "ShippedDate", "Freight", "ShipName", "ShipAddress", "ShipCity", "ShipRegion", "ShipPostalCode", "ShipCountry" ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "attributes" : [ "ProductID", "ProductName", "QuantityPerUnit", "UnitPrice", "UnitsInStock", "UnitsOnOrder", "ReorderLevel", "Discontinued" ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "attributes" : [ "CategoryID", "CategoryName", "Description", "Picture" ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "attributes" : [ "EmployeeID", "LastName", "FirstName", "Title", "TitleOfCourtesy", "BirthDate", "HireDate", "Address", "City", "Region", "PostalCode", "Country", "HomePhone", "Extension", "Photo", "Notes", "PhotoPath" ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "attributes" : [ "SupplierID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax", "HomePage" ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "attributes" : [ "CustomerID", "CompanyName", "ContactName", "ContactTitle", "Address", "City", "Region", "PostalCode", "Country", "Phone", "Fax" ]
     } ],
     "abstractionEdges" : [ {
-      "synonyms" : [ "sold" ],
+      "types" : [ "sold" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "orders" ],
       "directed" : false
     }, {
-      "synonyms" : [ "purchased" ],
+      "types" : [ "purchased" ],
       "attributes" : [ ],
       "sourceType" : [ "customers" ],
       "destinationType" : [ "orders" ],
       "directed" : false
     }, {
-      "synonyms" : [ "part_of" ],
+      "types" : [ "part_of" ],
       "attributes" : [ ],
       "sourceType" : [ "products" ],
       "destinationType" : [ "categories" ],
       "directed" : false
     }, {
-      "synonyms" : [ "reports_to" ],
+      "types" : [ "reports_to" ],
       "attributes" : [ ],
       "sourceType" : [ "employees" ],
       "destinationType" : [ "employees" ],
       "directed" : false
     }, {
-      "synonyms" : [ "product" ],
+      "types" : [ "product" ],
       "attributes" : [ "UnitPrice", "Quantity", "Discount" ],
       "sourceType" : [ "orders" ],
       "destinationType" : [ "products" ],
@@ -57,7 +57,7 @@
       "storageLayout" : "IGNORETIME"
     },
     "implementationNodes" : [ {
-      "synonyms" : [ "orders" ],
+      "types" : [ "orders" ],
       "tableName" : "Orders",
       "id" : [ {
         "columnName" : "OrderID",
@@ -111,7 +111,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "products" ],
+      "types" : [ "products" ],
       "tableName" : "Products",
       "id" : [ {
         "columnName" : "ProductID",
@@ -153,7 +153,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "categories" ],
+      "types" : [ "categories" ],
       "tableName" : "Categories",
       "id" : [ {
         "columnName" : "CategoryID",
@@ -179,7 +179,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "employees" ],
+      "types" : [ "employees" ],
       "tableName" : "Employees",
       "id" : [ {
         "columnName" : "EmployeeID",
@@ -257,7 +257,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "suppliers" ],
+      "types" : [ "suppliers" ],
       "tableName" : "Suppliers",
       "id" : [ {
         "columnName" : "SupplierID",
@@ -315,7 +315,7 @@
       } ],
       "restrictions" : [ ]
     }, {
-      "synonyms" : [ "customers" ],
+      "types" : [ "customers" ],
       "tableName" : "Customers",
       "id" : [ {
         "columnName" : "CustomerID",
@@ -370,7 +370,7 @@
       "restrictions" : [ ]
     } ],
     "implementationEdges" : [ {
-      "synonyms" : [ "SOLD" ],
+      "types" : [ "SOLD" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -384,7 +384,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PURCHASED" ],
+      "types" : [ "PURCHASED" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Customers",
@@ -398,7 +398,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PART_OF" ],
+      "types" : [ "PART_OF" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Products",
@@ -412,7 +412,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "SUPPLIES" ],
+      "types" : [ "SUPPLIES" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Suppliers",
@@ -426,7 +426,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "REPORTS_TO" ],
+      "types" : [ "REPORTS_TO" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Employees",
@@ -440,7 +440,7 @@
         } ]
       } ]
     }, {
-      "synonyms" : [ "PRODUCT" ],
+      "types" : [ "PRODUCT" ],
       "paths" : [ {
         "traversalHops" : [ {
           "sourceTableName" : "Orders",


### PR DESCRIPTION
Updating gTop Node and Edge attribute from "synonyms" to "types". Previous term caused confusion on readers, since they are actually used to denote nodes or edges types.

Different GQL may have different nomenclatures for it. In example, the Cypher equivalent to the gTop types would be called "labels"